### PR TITLE
fix(cloudsdk) Remove large backup directory.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,7 @@ wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip -qO /tmp/goo
 unzip -qd $VENDOR_DIR /tmp/google-cloud-sdk.zip
 $VENDOR_DIR/google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --bash-completion=false
 rm -rf /tmp/google-cloud-sdk.zip
+rm -rf $VENDOR_DIR/google-cloud-sdk/.install/
 
 # Copy .profile.d script for configuring gcloud
 mkdir -p $BUILD_DIR/.profile.d


### PR DESCRIPTION
Cloud SDK Installs leaves a large backup file. Since we don't ever
update cloudsdk live on the dyno we can safely remove it.